### PR TITLE
Pin every workflow action to an exact current release

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,12 +15,19 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
+      # setup-uv stopped publishing major tags at v8, deliberately: pinning to
+      # @v9 would be the supply-chain hole they closed. prune-cache is set
+      # explicitly because v9 flipped its default to false, which grows the
+      # Actions cache rather than trimming it.
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: "3.13"
+          prune-cache: true
 
       - name: Create test scratch directory
         run: |

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -16,12 +16,19 @@ jobs:
       contents: read
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
+      # setup-uv stopped publishing major tags at v8, deliberately: pinning to
+      # @v9 would be the supply-chain hole they closed. prune-cache is set
+      # explicitly because v9 flipped its default to false, which grows the
+      # Actions cache rather than trimming it.
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: "3.13"
+          prune-cache: true
 
       - name: Build package
         run: |
@@ -40,7 +47,7 @@ jobs:
           "from mlx_spatial.spatialkit import backend_info; info = backend_info(); assert info['native']; print(info)"
 
       - name: Upload package artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: mlx-spatial-dist
           path: dist/*
@@ -58,10 +65,13 @@ jobs:
       id-token: write
     steps:
       - name: Download package artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: mlx-spatial-dist
           path: dist
 
+      # PyPA suggests the floating release/v1 tag. This job is the one place in
+      # the repository that holds an OIDC id-token, so it pins an exact release
+      # instead: a compromised upstream tag here could publish as us.
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.14.2


### PR DESCRIPTION
Both workflows were a major version behind on checkout, **two majors behind on setup-uv**, and carried floating tags elsewhere.

| action | was | now |
|---|---|---|
| `actions/checkout` | `v6` | `v7.0.1` |
| `astral-sh/setup-uv` | `v7` | `v9.0.0` |
| `actions/upload-artifact` | `v7` | `v7.0.1` |
| `actions/download-artifact` | `v8` | `v8.0.1` |
| `pypa/gh-action-pypi-publish` | `release/v1` | `v1.14.2` |

Every version read from the upstream `releases/latest`, not from memory.

## The setup-uv jump needed its changelog, not just its version number

Crossing two majors, so I read both release notes before touching it. Two things came out of that:

**v8 stopped publishing major and minor tags deliberately.** Pinning to `@v9` would reopen exactly the supply-chain hole they closed after the tj-actions compromise — an exact release is the only supported form now. So this is not merely a style preference here; it is the upstream's requirement.

**v9's single breaking change flips `prune-cache` from `true` to `false`**, which grows the Actions cache instead of trimming it and can raise cost. That default is set back explicitly, so this upgrade changes versions and nothing else.

Their other breaking change — the `manifest-file` format — does not apply, since neither workflow defines one.

## Also

Both checkouts set `persist-credentials: false`. Neither workflow pushes, so nothing needs the token left in `.git/config`.

## Verification

⚠️ `workflow.yaml` only runs on a published release, so **no pull request exercises it** — the green check on this PR says nothing about the publish path. It was verified separately:

- all three workflow files parsed locally
- the release build job reproduced end to end:
  - `uv build` produced both artifacts, including the `macosx_14_0_arm64` native wheel
  - `check_release_artifacts.py` passed on both
  - the native backend smoke test reported `{'native': True, 'metal_available': True, ...}`
- the built wheel carries the new `Homepage`, `Keywords`, and description metadata

The Tests check on this PR does cover the risky half: it runs `checkout@v7.0.1` and `setup-uv@v9.0.0` on the same `macos-15` runner and with the same inputs that `workflow.yaml` uses.